### PR TITLE
Add Education and Game categories to metainfo

### DIFF
--- a/com.endlessnetwork.fablemaker.appdata.xml
+++ b/com.endlessnetwork.fablemaker.appdata.xml
@@ -15,6 +15,8 @@
     <p>Pop open the magical pages that offer a new approach to interacting with the beloved Aesop's Fables! Read and touch these time honored stories and then hack the pages to make them your own. The art, sounds and text can all be hacked, creating your unique fables you can share with others.</p>
   </description>
   <categories>
+    <category>Education</category>
+    <category>Game</category>
     <category>LearnToCode</category>
   </categories>
   <screenshots>


### PR DESCRIPTION
The listed `<categories>` have to be defined in the [freedesktop menu specification](https://specifications.freedesktop.org/menu-spec/latest/apas02.html). `LearnToCode` is not, which meant that outside of a forked Endless copy of gnome-software, the game wasn’t appearing in people’s app centres.

Fix that by adding categories which are defined in the specification. Keep `LearnToCode` for backwards compatibility with old versions of Endless gnome-software.